### PR TITLE
added example and removed redundant sct:packageDependency

### DIFF
--- a/feed-example.xml
+++ b/feed-example.xml
@@ -5,6 +5,12 @@
     <generator>SNOMED International</generator>
     <updated>2022-10-01T00:01:00</updated>
     <ncts:atomSyndicationFormatProfile>http://ns.electronichealth.net.au/ncts/syndication/asf/profile/1.0.0</ncts:atomSyndicationFormatProfile>
+    <!--
+        Entry example for the SNOMED CT-International Edition - edition snapshot package.
+        Features to note are
+            * no sct:packageDependency element because it is an edition package which contains all its dependencies
+            * this is a snapshot package (as opposed to delta or full) and has the category SCT_RF2_SNAPSHOT
+    -->
     <entry>
         <title>SNOMED CT-International Edition 2022-07-31 (RF2 SNAPSHOT)</title>
         <link rel="alternate" type="application/zip" href="https://mlds.ihtsdotools.org/api/releasePackages/167/releaseVersions/849892/releaseFiles/849900/download" length="266118090" ncts:sha256Hash="902ec61f6ada329bfd6bc487fe7adab0" />
@@ -21,11 +27,17 @@
         <summary>some narrative about the version</summary>
         <ncts:contentItemIdentifier>http://snomed.info/sct/900000000000207008</ncts:contentItemIdentifier>
         <ncts:contentItemVersion>http://snomed.info/sct/900000000000207008/version/20220731</ncts:contentItemVersion>
-        <sct:packageDependency>
-        </sct:packageDependency>
     </entry>
+    <!--
+        Entry example for the SNOMED CT-International Spanish Edition - extension snapshot package.
+        Features to note are
+            * sct:packageDependency element because this is an extension package which depends on content from other packages it does not contain
+            * sct:editionDependency element stating a dependency on the July 2022 International Edition
+            * sct:derivativeDependency element stating a dependency on the January 2022 Medical Dictionary for Regulatory Activities simple map module
+            * this is a snapshot package (as opposed to delta or full) and has the category SCT_RF2_SNAPSHOT
+    -->
     <entry>
-        <title>SNOMED CT-International Spanish Edition 2022-10-31 (RF2 SNAPSHOT)</title>
+        <title>SNOMED CT-International Spanish Extension 2022-10-31 (RF2 SNAPSHOT)</title>
         <link rel="alternate" type="application/zip" href="https://mlds.ihtsdotools.org/api/releasePackages/167/releaseVersions/849892/releaseFiles/849900/download" length="266118090" ncts:sha256Hash="902ec61f6ada329bfd6bc487fe7adab0" />
         <category term="SCT_RF2_SNAPSHOT" label="SNOMED CT RF2 Snapshot" scheme="http://ns.electronichealth.net.au/ncts/syndication/asf/scheme/1.0.0" />
         <author>
@@ -44,5 +56,28 @@
             <sct:editionDependency>http://snomed.info/sct/900000000000207008/version/20220731</sct:editionDependency>
             <sct:derivativeDependency>http://snomed.info/sct/816211006/version/20220131 </sct:derivativeDependency>
         </sct:packageDependency>
+    </entry>
+    <!--
+        Entry example of a national extension, the SNOMED CT Australian Edition - edition full package.
+        Features to note are
+            * no sct:packageDependency element because it is an edition package which contains all its dependencies
+            * this is a full package (as opposed to delta or snapshot) and has the category SCT_RF2_FULL
+    -->
+    <entry>
+        <title>SNOMED CT-AU 30 November 2022 (RF2 FULL)</title>
+        <link rel="alternate" type="application/zip" href="https://api.healthterminologies.gov.au/syndication/v1/au/gov/ehealthterminology/snomedct-au/NCTS_SCT_RF2_DISTRIBUTION_32506021000036107/20221130/NCTS_SCT_RF2_DISTRIBUTION_32506021000036107-20221130-FULL.zip" length="274406331" ncts:sha256Hash="8130cc90b38e8608380dd80e3b94740584270da5ae79f58d1a5281ac80809095" />
+        <category term="SCT_RF2_FULL" label="SNOMED CT RF2 Full" scheme="http://ns.electronichealth.net.au/ncts/syndication/asf/scheme/1.0.0" />
+        <author>
+            <name>Australian Digital Health Agency</name>
+            <uri>http://www.digitalhealth.gov.au</uri>
+            <email>help@digitalhealth.gov.au</email>
+        </author>
+        <id>urn:uuid:5cfaebe3-c1dd-312a-a15a-79bfd9e4d9bb</id>
+        <rights>Copyright 2022 Australian Digital Health Agency. This content contains information which is protected by copyright. All Rights Reserved. No part of this work may be reproduced or used in any form or by any means - graphic, electronic, or mechanical, including photocopying, recording, taping, or information storage and retrieval systems - without the permission of the Australian Digital Health Agency. IHTSDO (SNOMED CT) This material includes SNOMED Clinical Terms (TM) (SNOMED CT (R)) which is used by permission of the International Health Terminology Standards Development Organisation (IHTSDO). All rights reserved. SNOMED CT (R) was originally created by The College of American Pathologists. "SNOMED" and "SNOMED CT" are registered trademarks of the IHTSDO, (http://www.ihtsdo.org/).</rights>
+        <updated>2022-11-23T10:50:00Z</updated>
+        <published>2022-11-23T10:50:00Z</published>
+        <summary>SNOMED CT-AU is the Australian extension to the Systematized Nomenclature of Medicine, Clinical Terms (SNOMED CT), incorporating all Australian-developed terminology including the Australian Medicines Terminology (AMT) along with the core international data. SNOMED CT-AU provides local variations and customisations of terms relevant to the Australian healthcare sector for implementation in Australian clinical IT systems.</summary>
+        <ncts:contentItemIdentifier>http://snomed.info/sct/32506021000036107</ncts:contentItemIdentifier>
+        <ncts:contentItemVersion>http://snomed.info/sct/32506021000036107/version/20221130</ncts:contentItemVersion>
     </entry>
 </feed>


### PR DESCRIPTION
- Added an example of SNOMED CT-AU as an example national extension. 
- Removed redundant sct:packageDependency from the international edition example which helps clarify it is an edition as opposed to an extension package. 
- Updated the Spanish edition example to include Extension in the title to help clarify it is an extension package, not an edition package. 
- Added explanatory comments.